### PR TITLE
Changing @BUFFER_SIZE and @BUFFER_MAX_AGE before converting to integer.

### DIFF
--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -32,8 +32,8 @@ module Sensu::Extension
       username         = influxdb_config['username']
       password         = influxdb_config['password']
       auth_queryparam  = if username.nil? or password.nil? then "" else "&u=#{username}&p=#{password}" end
-      @BUFFER_SIZE     = influxdb_config['buffer_size'] || 100
-      @BUFFER_MAX_AGE  = influxdb_config['buffer_max_age'] || 10
+      @BUFFER_SIZE     = influxdb_config.key?('buffer_size') ? influxdb_config['buffer_size'].to_i :  100
+      @BUFFER_MAX_AGE  = influxdb_config.key?('buffer_max_age') ? influxdb_config['buffer_max_age'].to_i : 10
 
       @uri = URI("#{protocol}://#{hostname}:#{port}/write?db=#{database}&precision=#{precision}#{rp_queryparam}#{auth_queryparam}")
       @http = Net::HTTP::new(@uri.host, @uri.port)         


### PR DESCRIPTION
When passing BUFFER_SIZE and BUFFER_MAX_AGE via environment properties, their value gets treated as a string and comparison fails.
Adding a check to see if properties has been passed as environment variables before converting to integer, or default values if not.
