### PR TITLE
Adding Retry Payload and Event Tags functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Example of a minimal configuration file
 | retention_policy  |                  none |
 | username          |                  none |
 | password          |                  none |
+| retry_file        | /var/log/sensu/<br/>influxdb_retry_payload.log|
 
 (*) s = seconds. Other valid options are n, u, ms, m, h. See [influxdb docs](https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html) for more details
-
 
 3) Add the extension to your sensu-handler configuration 
 
@@ -165,7 +165,7 @@ measurement = app.downloads, tags = platform => iOS;device => iPad , value = 92,
 
 The event output tags will be merged with client and check definition tags and sent to InfluxDB as usual.
 
-#performance
+# Performance
 
 The extension will buffer up points until it reaches the configured **buffer_size** length or **buffer_max_age**, and then post all the points in the buffer to InfluxDB. 
 Depending on your load, you will want to tune these configurations to match your environment.
@@ -178,3 +178,10 @@ If you set the **buffer_size** to 1000, and you have a event-frequency of 100 pe
 However, if you set the **buffer_max_age** to 5 seconds, it will flush the buffer each time it exeeds this limit.
 
 I recommend testing different **buffer_size**s and **buffer_max_age**s depending on your environment and requirements.
+
+
+# Retry payload
+
+There are cases where the target InfluxDB endpoint is not available due to service or network unavailability. InfluxDB gives a response code of `204` on successful processing of the post request. If the request failed or gives a different return code, then the payload will be written to a file. You can process it later and send it to InfluxDB for once it is up.
+
+You can set the retry file in the influxdb.json by setting the variable `retry_file`. The default value is `/var/log/sensu/influxdb_retry_payload.log`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ Example check definition:
 
 If both the client and the check tags have the same key, the one defined on the check will overwrite/win the merge.
 
+### Event Output Tags
+
+This extension already provides check level and client level tags and now can provide event output tags. This will help us reducing number of sensu checks and provide better flexibility and control.
+
+Example -
+Let's say we configured the sensu check output to be :
+
+```
+app.downloads.eventtags.platform.iOS 26 1476047752
+app.downloads.eventtags.platform.android 52 1476047752
+app.downloads.eventtags.platform.others 12 1476047752
+```
+
+The extension will split the output of the measurement on eventtags. Then it will slice the second part into tag key and values. From above example, the transformed output will be -
+```
+measurement = app.downloads, tags = platform => iOS , value = 26, timestamp = 1476047752 
+measurement = app.downloads, tags = platform => android , value = 52, timestamp = 1476047752
+measurement = app.downloads, tags = platform => others , value = 12, timestamp = 1476047752
+```
+
+You can create multiple tags also, for example :
+
+```
+app.downloads.eventtags.platform.iOS.device.iPad 92 1476047752
+```
+will be transformed to :
+```
+measurement = app.downloads, tags = platform => iOS;device => iPad , value = 92, timestamp = 1476047752 
+```
+
+The event output tags will be merged with client and check definition tags and sent to InfluxDB as usual.
+
 #performance
 
 The extension will buffer up points until it reaches the configured **buffer_size** length or **buffer_max_age**, and then post all the points in the buffer to InfluxDB. 

--- a/influxdb-extension.json.tmpl
+++ b/influxdb-extension.json.tmpl
@@ -8,7 +8,7 @@
         "password": "<influxdb password>",
         "buffer_size": 100,
         "buffer_max_age": 10,
-        "precision": "s"
+        "precision": "s",
+        "retry_file": "<retry payload file>"
     }
 }
-

--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -5,7 +5,7 @@ require "json"
 
 module Sensu::Extension
   class InfluxDB < Handler
-    
+
     @@extension_name = "influxdb-extension"
 
     def name
@@ -18,9 +18,9 @@ module Sensu::Extension
 
     def post_init
       influxdb_config = settings[@@extension_name]
-      
+
       validate_config(influxdb_config)
-       
+
       hostname         = influxdb_config[:hostname] 
       port             = influxdb_config[:port] || "8086"
       database         = influxdb_config[:database]
@@ -36,7 +36,7 @@ module Sensu::Extension
       @BUFFER_MAX_AGE  = if influxdb_config.key?(:buffer_max_age) then influxdb_config[:buffer_max_age].to_i else 10 end
 
       @uri = URI("#{protocol}://#{hostname}:#{port}/write?db=#{database}&precision=#{precision}#{rp_queryparam}#{auth_queryparam}")
-      @http = Net::HTTP::new(@uri.host, @uri.port)         
+      @http = Net::HTTP::new(@uri.host, @uri.port)
       @buffer = []
       @buffer_flushed = Time.now.to_i
 
@@ -48,7 +48,7 @@ module Sensu::Extension
         if buffer_too_old? or buffer_too_big?
           flush_buffer
         end
-        
+
         event = JSON.parse(event)
         client_tags = event["client"]["tags"] || Hash.new
         check_tags = event["check"]["tags"] || Hash.new
@@ -56,47 +56,52 @@ module Sensu::Extension
         output = event["check"]["output"]
 
         output.split(/\r\n|\n/).each do |line|
-            measurement, field_value, timestamp = line.split(/\s+/)
+          measurement, field_value, timestamp = line.split(/\s+/)
 
-            if not is_number?(timestamp)
-              @logger.debug("invalid timestamp, skipping line in event #{event}")
-              next
+          if not is_number?(timestamp)
+            @logger.debug("invalid timestamp, skipping line in event #{event}")
+            next
+          end
+
+          # Get event output tags
+          if measurement.include?('eventtags')
+            only_measurement, tagstub = measurement.split('.eventtags.',2)
+            event_tags = Hash.new()
+            tagstub.split('.').each_slice(2) do |key, value|
+              event_tags[key] = value
             end
-            
-            point = "#{measurement}#{tags} value=#{field_value} #{timestamp}" 
-            @buffer.push(point)
-            @logger.debug("#{@@extension_name}: stored point in buffer (#{@buffer.length}/#{@BUFFER_SIZE})")
+            measurement = only_measurement
+            tags = create_tags(client_tags.merge(check_tags).merge(event_tags))
+          end
+
+          point = "#{measurement}#{tags} value=#{field_value} #{timestamp}" 
+          @buffer.push(point)
+          @logger.debug("#{@@extension_name}: stored point in buffer (#{@buffer.length}/#{@BUFFER_SIZE})")
         end
       rescue => e
         @logger.debug("#{@@extension_name}: unable to post payload to influxdb for event #{event} - #{e.backtrace.to_s}")
       end
     end
-    
 
     def create_tags(tags)
-        begin
-            # sorting tags alphabetically in order to increase influxdb performance
-            sorted_tags = Hash[tags.sort]
-
-            tag_string = "" 
-
-            sorted_tags.each do |tag, value|
-                next if value.to_s.empty? # skips tags without values
-                tag_string += ",#{tag}=#{value}"
-            end
-
-            @logger.debug("#{@@extension_name}: created tags: #{tag_string}")
-            tag_string
-        rescue => e
-            @logger.debug("#{@@extension_name}: unable to create tag string from #{tags} - #{e.backtrace.to_s}")
-            ""
+      begin
+        # sorting tags alphabetically in order to increase influxdb performance
+        sorted_tags = Hash[tags.sort]
+        tag_string = "" 
+        sorted_tags.each do |tag, value|
+          next if value.to_s.empty? # skips tags without values
+          tag_string += ",#{tag}=#{value}"
         end
+        @logger.debug("#{@@extension_name}: created tags: #{tag_string}")
+        tag_string
+      rescue => e
+        @logger.debug("#{@@extension_name}: unable to create tag string from #{tags} - #{e.backtrace.to_s}")
+      end
     end
 
     def send_to_influxdb(payload)
-        request = Net::HTTP::Post.new(@uri.request_uri)
-        request.body = payload 
-        
+     request = Net::HTTP::Post.new(@uri.request_uri)
+        request.body = payload
         @logger.debug("#{@@extension_name}: writing payload #{payload} to endpoint #{@uri.to_s}")
         response = @http.request(request)
         @logger.info("#{@@extension_name}: influxdb http response code = #{response.code}, body = #{response.body}")
@@ -112,11 +117,11 @@ module Sensu::Extension
     def buffer_too_old?
       buffer_age = Time.now.to_i - @buffer_flushed
       buffer_age >= @BUFFER_MAX_AGE
-    end 
-    
+    end
+
     def buffer_too_big?
       @buffer.length >= @BUFFER_SIZE
-    end 
+    end
 
     def validate_config(config)
       if config.nil?
@@ -132,6 +137,7 @@ module Sensu::Extension
 
     def is_number?(input)
       true if Integer(input) rescue false
-    end 
+    end
+
   end
 end


### PR DESCRIPTION
Added the possibility of adding event output level tags so that we can decrease the number of sensu checks and influxdb measurements. Also added the code which will save the payload to a file when influxdb is not reachable or not processing the payload. We can later send it to influx once it is up.
