### PR TITLE
fixes https://github.com/jhrv/sensu-influxdb-extension/issues/15

### DIFF
--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -70,6 +70,7 @@ module Sensu::Extension
       rescue => e
         @logger.debug("#{@@extension_name}: unable to post payload to influxdb for event #{event} - #{e.backtrace.to_s}")
       end
+      yield('', 0)
     end
     
 


### PR DESCRIPTION
ripped this off from https://github.com/seegno/sensu-influxdb-extension/pull/14 and also the discussion at sensu (https://github.com/sensu/sensu/issues/998)

This will fix the problem with sensu-server failing to restart with this message:

{"timestamp":"2016-11-16T19:25:57.227565+0000","level":"info","message":"completing work in progress","in_progress":{"check_results":0,"events":10}}