### PR TITLE
Consolidated multiple fields into single record

### DIFF
--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -59,6 +59,7 @@ module Sensu::Extension
         if not @PROXY_MODE
           client_tags = event["client"]["tags"] || Hash.new
           check_tags = event["check"]["tags"] || Hash.new
+          client_tags["host"] = event["client"]["name"]
           tags = create_tags(client_tags.merge(check_tags))
         end
         

--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -91,7 +91,7 @@ module Sensu::Extension
         @buffer.push(newPoint)
 
       rescue => e
-        @logger.debug("#{@@extension_name}: unable to post payload to influxdb for event #{event} - #{e.backtrace.to_s}")
+        @logger.error("#{@@extension_name}: unable to post payload to influxdb for event #{event} - #{e.backtrace.to_s}")
       end
       yield('', 0)
     end
@@ -111,7 +111,7 @@ module Sensu::Extension
             @logger.debug("#{@@extension_name}: created tags: #{tag_string}")
             tag_string
         rescue => e
-            @logger.debug("#{@@extension_name}: unable to create tag string from #{tags} - #{e.backtrace.to_s}")
+            @logger.error("#{@@extension_name}: unable to create tag string from #{tags} - #{e.backtrace.to_s}")
             ""
         end
     end

--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -41,6 +41,7 @@ module Sensu::Extension
       @http = Net::HTTP::new(@uri.host, @uri.port)         
       @buffer = []
       @buffer_flushed = Time.now.to_i
+      @consolidatedMeasurment = []
 
       @logger.info("#{@@extension_name}: successfully initialized config: hostname: #{hostname}, port: #{port}, database: #{database}, uri: #{@uri.to_s}, username: #{username}, buffer_size: #{@BUFFER_SIZE}, buffer_max_age: #{@BUFFER_MAX_AGE}")
     end
@@ -64,18 +65,27 @@ module Sensu::Extension
         output.split(/\r\n|\n/).each do |point|
             if not @PROXY_MODE
               measurement, field_value, timestamp = point.split(/\s+/)
+              measurmentField = measurement.split('.')
 
               if not is_number?(timestamp)
                 @logger.debug("invalid timestamp, skipping line in event #{event}")
                 next
               end
 
-              point = "#{measurement}#{tags} value=#{field_value} #{timestamp}" 
+              point = "#{measurmentField[2]}=#{field_value}"
             end
 
-            @buffer.push(point)
+            @consolidatedMeasurment.push(point)
             @logger.debug("#{@@extension_name}: stored point in buffer (#{@buffer.length}/#{@BUFFER_SIZE})")
         end
+
+        table = event["client"]["name"] + "." + event["check"]["name"]
+        fields = @consolidatedMeasurment.join(",")
+        @consolidatedMeasurment=[]
+        eventTimestamp = event["check"]["executed"]
+        newPoint = "#{table}#{tags} #{fields} #{eventTimestamp}"
+        @buffer.push(newPoint)
+
       rescue => e
         @logger.debug("#{@@extension_name}: unable to post payload to influxdb for event #{event} - #{e.backtrace.to_s}")
       end
@@ -109,7 +119,7 @@ module Sensu::Extension
         @logger.debug("#{@@extension_name}: writing payload #{payload} to endpoint #{@uri.to_s}")
         begin
           response = @http.request(request)
-          @logger.info("#{@@extension_name}: influxdb http response code = #{response.code}, body = #{response.body}")
+          @logger.debug("#{@@extension_name}: influxdb http response code = #{response.code}, body = #{response.body}")
         rescue => e
           @logger.error("unable to send payload to InfluxDB #{e}")
           ""

--- a/influxdb-extension.rb
+++ b/influxdb-extension.rb
@@ -65,14 +65,17 @@ module Sensu::Extension
         output.split(/\r\n|\n/).each do |point|
             if not @PROXY_MODE
               measurement, field_value, timestamp = point.split(/\s+/)
-              measurmentField = measurement.split('.')
+              measurmentFieldWorking = measurement.split('.')
+              measurementFieldWorking2 = measurmentFieldWorking.drop(2)
+              measurementField = measurementFieldWorking2.join(".")
 
               if not is_number?(timestamp)
                 @logger.debug("invalid timestamp, skipping line in event #{event}")
                 next
               end
 
-              point = "#{measurmentField[2]}=#{field_value}"
+              point = "#{measurementField}=#{field_value}"
+              #point = "#{measurmentField[2]}=#{field_value}"
             end
 
             @consolidatedMeasurment.push(point)


### PR DESCRIPTION
Changed the way the extension inserts data into Influx so that multiple measurements in a check all insert into the same table. For example, in a CPU check the guest, idle, system, user, etc fields all insert into a single record in accordance with Influx’s line protocol with multiple fields and associated measurments. Also changed one logger entry to debug so that every time a call is made to Influx it doesn’t log the response code.

I am not a Ruby programmer so there certainly could be a better way to accomplish this.